### PR TITLE
refactor: libfastrace C++ interface for improved safety and usability

### DIFF
--- a/examples/get_started2.cc
+++ b/examples/get_started2.cc
@@ -3,47 +3,47 @@
 #include <libfastrace/libfastrace.h>
 
 #include <array>
+#include <vector>
 
-int main(void) {
-  std::array<const char*, 10> keys = {"pk1", "pk2", "pk3", "pk4", "ck1",
+int main() {
+  std::array<std::string, 10> keys = {"pk1", "pk2", "pk3", "pk4", "ck1",
                                       "ck2", "ck3", "ck4", "ck5", "ck6"};
-  std::array<const char*, 10> vals = {"pv1", "pv2", "pv3", "pv4", "cv1",
+  std::array<std::string, 10> vals = {"pv1", "pv2", "pv3", "pv4", "cv1",
                                       "cv2", "cv3", "cv4", "cv5", "cv6"};
 
-  fastrace_glue::ftr_set_cons_rptr();
-  auto p = fastrace_glue::ftr_create_rand_span_ctx();
-  auto r = fastrace_glue::ftr_create_root_span("root", p);
+  fastrace::setConsoleReporter();
 
-  fastrace_glue::ftr_add_ent_to_par(
-      "parent event", r, rust::Slice<const char* const>(keys.data(), 2),
-      rust::Slice<const char* const>(vals.data(), 2));
+  {
+    fastrace::SpanContext context;
+    fastrace::Span rootSpan("root", context);
 
-  fastrace_glue::ftr_span_with_prop(r, "phello", "pworld");
-  fastrace_glue::ftr_span_with_props(
-      r, rust::Slice<const char* const>(keys.data() + 2, 2),
-      rust::Slice<const char* const>(vals.data() + 2, 2));
+    std::vector<std::pair<std::string, std::string>> parentEventProps = {
+        {keys[0], vals[0]}, {keys[1], vals[1]}};
+    rootSpan.addEvent("parent event", parentEventProps);
 
-  auto g = fastrace_glue::ftr_set_loc_par_to_span(r);
+    rootSpan.addProperty("phello", "pworld");
+    std::vector<std::pair<std::string, std::string>> rootProps = {
+        {keys[2], vals[2]}, {keys[3], vals[3]}};
+    rootSpan.addProperties(rootProps);
 
-  auto ls = fastrace_glue::ftr_create_loc_span_enter("child");
-  fastrace_glue::ftr_add_ent_to_loc_par(
-      "child event", rust::Slice<const char* const>(keys.data() + 4, 2),
-      rust::Slice<const char* const>(vals.data() + 4, 2));
+    fastrace::LocalParentGuard guard(rootSpan);
+    fastrace::LocalSpan childSpan("child");
 
-  fastrace_glue::ftr_loc_span_add_prop("chello", "cworld");
-  fastrace_glue::ftr_loc_span_add_props(
-      rust::Slice<const char* const>(keys.data() + 6, 2),
-      rust::Slice<const char* const>(vals.data() + 6, 2));
+    std::vector<std::pair<std::string, std::string>> childEventProps = {
+        {keys[4], vals[4]}, {keys[5], vals[5]}};
+    childSpan.addEvent("child event", childEventProps);
 
-  fastrace_glue::ftr_loc_span_with_prop(ls, "chello2", "cworld2");
-  fastrace_glue::ftr_loc_span_with_props(
-      ls, rust::Slice<const char* const>(keys.data() + 8, 2),
-      rust::Slice<const char* const>(vals.data() + 8, 2));
+    childSpan.addProperty("chello", "cworld");
+    std::vector<std::pair<std::string, std::string>> childProps1 = {
+        {keys[6], vals[6]}, {keys[7], vals[7]}};
+    childSpan.addProperties(childProps1);
 
-  fastrace_glue::ftr_destroy_loc_span(ls);
-  fastrace_glue::ftr_destroy_loc_par_guar(g);
-  fastrace_glue::ftr_destroy_span(r);
+    childSpan.addProperty("chello2", "cworld2");
+    std::vector<std::pair<std::string, std::string>> childProps2 = {
+        {keys[8], vals[8]}, {keys[9], vals[9]}};
+    childSpan.addProperties(childProps2);
+  }
 
-  fastrace_glue::ftr_flush();
+  fastrace::flush();
   return 0;
 }

--- a/examples/synchronous2.cc
+++ b/examples/synchronous2.cc
@@ -5,41 +5,36 @@
 #include <thread>
 
 void func2(int i) {
-  auto ls = fastrace_glue::ftr_create_loc_span_enter("func2");
+  fastrace::LocalSpan ls("func2");
   std::this_thread::sleep_for(std::chrono::milliseconds(i * 1));
-  fastrace_glue::ftr_destroy_loc_span(ls);
 }
 
 void func1(int i) {
-  auto ls = fastrace_glue::ftr_create_loc_span_enter("func1");
+  fastrace::LocalSpan ls("func1");
   std::this_thread::sleep_for(std::chrono::milliseconds(i * 1));
   func2(i);
-  fastrace_glue::ftr_destroy_loc_span(ls);
 }
 
 int main(void) {
-  auto ecfg = fastrace_glue::ftr_create_def_otlp_exp_cfg();
-  auto cfg = fastrace_glue::ftr_create_def_coll_cfg();
+  auto ecfg = fastrace::createDefaultOTLPExporterConfig();
+  auto cfg = fastrace::createDefaultCollectorConfig();
 
-  auto rptr = fastrace_glue::ftr_create_otel_rptr(ecfg);
-  fastrace_glue::ftr_set_otel_rptr(rptr, cfg);
+  auto rptr = fastrace::createOpenTelemetryReporter(ecfg);
+  fastrace::setOpenTelemetryReporter(rptr, cfg);
 
-  auto p = fastrace_glue::ftr_create_rand_span_ctx();
-  auto r = fastrace_glue::ftr_create_root_span("root", p);
-  auto g = fastrace_glue::ftr_set_loc_par_to_span(r);
-  auto ls = fastrace_glue::ftr_create_loc_span_enter("a span");
-  // ftr_add_prop_to_loc_span(ls, "a property", "a value");
+  {
+    fastrace::SpanContext p;
+    fastrace::Span rootSpan("root", p);
+    fastrace::LocalParentGuard g(rootSpan);
+    fastrace::LocalSpan ls("a span");
+    ls.addProperty("k1", "v1");
 
-  for (auto i = 1; i <= 10; i++) {
-    func1(i);
+    for (auto i = 1; i <= 10; i++) {
+      func1(i);
+    }
   }
 
-  fastrace_glue::ftr_destroy_loc_span(ls);
-  fastrace_glue::ftr_destroy_loc_par_guar(g);
-  fastrace_glue::ftr_destroy_span(r);
+  fastrace::flush();
 
-  fastrace_glue::ftr_flush();
-
-  fastrace_glue::ftr_destroy_otel_rptr(rptr);
   return 0;
 }

--- a/include/libfastrace.h
+++ b/include/libfastrace.h
@@ -316,6 +316,18 @@ class Span {
    * span as parent. */
   explicit Span(const char *name);
 
+  /** @brief Move constructor */
+  Span(Span &&other) noexcept;
+
+  /** @brief Move assignment operator */
+  Span &operator=(Span &&other) noexcept;
+
+  /** @brief Copy constructor (deleted to ensure unique ownership) */
+  Span(const Span &) = delete;
+
+  /** @brief Copy assignment operator (deleted to ensure unique ownership) */
+  Span &operator=(const Span &) = delete;
+
   /** @brief Destroys the span, submitting it to the reporter if it's a root
    * span. */
   ~Span();

--- a/src/libfastrace.cpp
+++ b/src/libfastrace.cpp
@@ -3,7 +3,6 @@
 #include "libfastrace.h"
 
 #include <cstring>
-#include <new>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -281,6 +280,15 @@ Span::Span(const char* name, const Span& parent)
 
 Span::Span(const char* name)
     : span_(new ftr_span(ftr_create_child_span_enter_loc(name))) {}
+
+Span::Span(Span&& other) noexcept : span_(std::move(other.span_)) {}
+
+Span& Span::operator=(Span&& other) noexcept {
+  if (this != &other) {
+    span_ = std::move(other.span_);
+  }
+  return *this;
+}
 
 Span::~Span() {
   if (span_) {

--- a/src/libfastrace.cpp
+++ b/src/libfastrace.cpp
@@ -1,261 +1,436 @@
 // Copyright 2023 Wenbo Zhang. Licensed under Apache-2.0.
 
 #include "libfastrace.h"
+
+#include <cstring>
+#include <new>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
 #include "lib.rs.h"
+
+namespace {
+
+template <typename T>
+class RustTypeWrapper {
+  typename std::aligned_storage<sizeof(T), alignof(T)>::type storage;
+  T* ptr;
+
+ public:
+  template <typename... Args>
+  RustTypeWrapper(Args&&... args)
+      : ptr(new(&storage) T(std::forward<Args>(args)...)) {}
+
+  ~RustTypeWrapper() { ptr->~T(); }
+
+  T& get() { return *ptr; }
+  const T& get() const { return *ptr; }
+};
+
+template <typename CType, typename RustType, typename... Args>
+CType call_rust_function(RustType (*rust_func)(Args...),
+                         typename std::decay<Args>::type... args) {
+  static_assert(sizeof(CType) == sizeof(RustType),
+                "CType must be the same size as RustType");
+  static_assert(alignof(CType) == alignof(RustType),
+                "CType must have the same alignment as RustType");
+
+  RustTypeWrapper<RustType> wrapper(
+      rust_func(std::forward<decltype(args)>(args)...));
+
+  return *reinterpret_cast<CType*>(&wrapper.get());
+}
+
+template <typename Type, typename... Args>
+Type call_rust_function(Type (*rust_func)(Args...),
+                        typename std::decay<Args>::type... args) {
+  return rust_func(std::forward<decltype(args)>(args)...);
+}
+
+template <typename T>
+T deref_or_self(const T* ptr) {
+  static const T default_value = T();
+  return ptr ? *ptr : default_value;
+}
+
+}  // anonymous namespace
 
 extern "C" {
 
-union _ftr_span_ctx {
-  ftr_span_ctx c;
-  ffi::ftr_span_ctx f;
-};
-
-union _ftr_span {
-  ftr_span c;
-  ffi::ftr_span f;
-};
-
-union _ftr_loc_par_guar {
-  ftr_loc_par_guar c;
-  ffi::ftr_loc_par_guar f;
-};
-
-union _ftr_loc_span {
-  ftr_loc_span c;
-  ffi::ftr_loc_span f;
-};
-
-union _ftr_loc_coll {
-  ftr_loc_coll c;
-  ffi::ftr_loc_coll f;
-};
-
-union _ftr_loc_spans {
-  ftr_loc_spans c;
-  ffi::ftr_loc_spans f;
-};
-
-union _ftr_coll_cfg {
-  ftr_coll_cfg c;
-  ffi::ftr_coll_cfg f;
-};
-
-union _ftr_otlp_exp_cfg {
-  ftr_otlp_exp_cfg c;
-  ffi::ftr_otlp_exp_cfg f;
-};
-
-union _ftr_otel_rptr {
-  ftr_otel_rptr c;
-  ffi::ftr_otel_rptr f;
-};
-
 ftr_span_ctx ftr_create_rand_span_ctx() {
-  union _ftr_span_ctx _msc = {
-      .f = fastrace_glue::ftr_create_rand_span_ctx(),
-  };
-  return std::move(_msc.c);
+  return call_rust_function<ftr_span_ctx>(
+      &fastrace_glue::ftr_create_rand_span_ctx);
 }
 
-ftr_span_ctx ftr_create_span_ctx(ftr_span const *span) {
-  union _ftr_span _p = {
-      .c = *span,
-  };
-  union _ftr_span_ctx _msc = {
-      .f = fastrace_glue::ftr_create_span_ctx(_p.f),
-  };
-  return std::move(_msc.c);
+ftr_span_ctx ftr_create_span_ctx(const ftr_span* span) {
+  ffi::ftr_span rust_span =
+      deref_or_self(reinterpret_cast<const ffi::ftr_span*>(span));
+  return call_rust_function<ftr_span_ctx>(&fastrace_glue::ftr_create_span_ctx,
+                                          rust_span);
 }
 
 ftr_span_ctx ftr_create_span_ctx_loc() {
-  union _ftr_span_ctx _msc = {
-      .f = fastrace_glue::ftr_create_span_ctx_loc(),
-  };
-  return std::move(_msc.c);
+  return call_rust_function<ftr_span_ctx>(
+      &fastrace_glue::ftr_create_span_ctx_loc);
 }
 
-ftr_span ftr_create_root_span(const char *name, ftr_span_ctx parent) {
-  union _ftr_span _ms = {
-      .f = fastrace_glue::ftr_create_root_span(name,
-                                               *(ffi::ftr_span_ctx *)(&parent)),
-  };
-  return std::move(_ms.c);
+ftr_span_ctx ftr_span_ctx_set_sampled(ftr_span_ctx ctx, bool sampled) {
+  return call_rust_function<ftr_span_ctx>(
+      &fastrace_glue::ftr_span_ctx_set_sampled,
+      *reinterpret_cast<ffi::ftr_span_ctx*>(&ctx), sampled);
 }
 
-ftr_span ftr_create_child_span_enter(const char *name, ftr_span const *parent) {
-  union _ftr_span _p = {
-      .c = *parent,
-  };
-  union _ftr_span _ms = {
-      .f = fastrace_glue::ftr_create_child_span_enter(name, _p.f),
-  };
-  return std::move(_ms.c);
+ftr_span ftr_create_root_span(const char* name, ftr_span_ctx parent) {
+  const ffi::ftr_span_ctx& rust_parent =
+      *reinterpret_cast<const ffi::ftr_span_ctx*>(&parent);
+  return call_rust_function<ftr_span>(&fastrace_glue::ftr_create_root_span,
+                                      rust::Str(name), rust_parent);
 }
 
-ftr_span ftr_create_child_span_enter_mul(const char *name,
-                                         ftr_span const *parents, size_t n) {
-  union _ftr_span _ms = {
-      .f = fastrace_glue::ftr_create_child_span_enter_mul(
-          name, rust::Slice<const ffi::ftr_span>(
-                    reinterpret_cast<const ffi::ftr_span *>(parents), n)),
-  };
-  return std::move(_ms.c);
+ftr_span ftr_create_child_span_enter(const char* name, const ftr_span* parent) {
+  ffi::ftr_span rust_parent =
+      deref_or_self(reinterpret_cast<const ffi::ftr_span*>(parent));
+  return call_rust_function<ftr_span>(
+      &fastrace_glue::ftr_create_child_span_enter, rust::Str(name),
+      rust_parent);
 }
 
-ftr_span ftr_create_child_span_enter_loc(const char *name) {
-  union _ftr_span _ms = {
-      .f = fastrace_glue::ftr_create_child_span_enter_loc(name),
-  };
-  return std::move(_ms.c);
+ftr_span ftr_create_child_span_enter_mul(const char* name,
+                                         const ftr_span* parents, size_t n) {
+  return call_rust_function<ftr_span>(
+      &fastrace_glue::ftr_create_child_span_enter_mul, rust::Str(name),
+      rust::Slice<const ffi::ftr_span>(
+          reinterpret_cast<const ffi::ftr_span*>(parents), n));
+}
+
+ftr_span ftr_create_child_span_enter_loc(const char* name) {
+  return call_rust_function<ftr_span>(
+      &fastrace_glue::ftr_create_child_span_enter_loc, rust::Str(name));
 }
 
 void ftr_cancel_span(ftr_span span) {
-  fastrace_glue::ftr_cancel_span(*(ffi::ftr_span *)(&span));
+  fastrace_glue::ftr_cancel_span(*reinterpret_cast<ffi::ftr_span*>(&span));
 }
 
 void ftr_destroy_span(ftr_span span) {
-  fastrace_glue::ftr_destroy_span(*(ffi::ftr_span *)(&span));
+  fastrace_glue::ftr_destroy_span(*reinterpret_cast<ffi::ftr_span*>(&span));
 }
 
-ftr_loc_par_guar ftr_set_loc_par_to_span(ftr_span const *span) {
-  union _ftr_span _p = {
-      .c = *span,
-  };
-  union _ftr_loc_par_guar _mlpg = {
-      .f = fastrace_glue::ftr_set_loc_par_to_span(_p.f),
-  };
-  return std::move(_mlpg.c);
+ftr_loc_par_guar ftr_set_loc_par_to_span(const ftr_span* span) {
+  ffi::ftr_span rust_span =
+      deref_or_self(reinterpret_cast<const ffi::ftr_span*>(span));
+  return call_rust_function<ftr_loc_par_guar>(
+      &fastrace_glue::ftr_set_loc_par_to_span, rust_span);
 }
 
-void ftr_span_with_prop(ftr_span *span, const char *key, const char *val) {
-  fastrace_glue::ftr_span_with_prop(*reinterpret_cast<ffi::ftr_span *>(span),
-                                    key, val);
+void ftr_span_with_prop(ftr_span* span, const char* key, const char* val) {
+  fastrace_glue::ftr_span_with_prop(*reinterpret_cast<ffi::ftr_span*>(span),
+                                    rust::Str(key), rust::Str(val));
 }
 
-void ftr_span_with_props(ftr_span *span, const char **keys, const char **vals,
+void ftr_span_with_props(ftr_span* span, const char** keys, const char** vals,
                          size_t n) {
-  fastrace_glue::ftr_span_with_props(*reinterpret_cast<ffi::ftr_span *>(span),
-                                     rust::Slice<const char *const>(keys, n),
-                                     rust::Slice<const char *const>(vals, n));
+  fastrace_glue::ftr_span_with_props(*reinterpret_cast<ffi::ftr_span*>(span),
+                                     rust::Slice<const char* const>(keys, n),
+                                     rust::Slice<const char* const>(vals, n));
 }
 
-void ftr_add_ent_to_par(const char *name, ftr_span *span, const char **keys,
-                        const char **vals, size_t n) {
-  fastrace_glue::ftr_add_ent_to_par(name,
-                                    *reinterpret_cast<ffi::ftr_span *>(span),
-                                    rust::Slice<const char *const>(keys, n),
-                                    rust::Slice<const char *const>(vals, n));
+void ftr_add_ent_to_par(const char* name, ftr_span* span, const char** keys,
+                        const char** vals, size_t n) {
+  std::vector<const char*> rust_keys(keys, keys + n);
+  std::vector<const char*> rust_vals(vals, vals + n);
+  fastrace_glue::ftr_add_ent_to_par(
+      rust::Str(name), *reinterpret_cast<ffi::ftr_span*>(span),
+      rust::Slice<const char* const>(rust_keys.data(), n),
+      rust::Slice<const char* const>(rust_vals.data(), n));
 }
 
 void ftr_destroy_loc_par_guar(ftr_loc_par_guar guard) {
-  fastrace_glue::ftr_destroy_loc_par_guar(*(ffi::ftr_loc_par_guar *)(&guard));
+  fastrace_glue::ftr_destroy_loc_par_guar(
+      *reinterpret_cast<ffi::ftr_loc_par_guar*>(&guard));
 }
 
-void ftr_push_child_spans_to_cur(ftr_span const *span,
+void ftr_push_child_spans_to_cur(const ftr_span* span,
                                  ftr_loc_spans local_span) {
-  union _ftr_span _p = {
-      .c = *span,
-  };
   fastrace_glue::ftr_push_child_spans_to_cur(
-      _p.f, *(ffi::ftr_loc_spans *)(&local_span));
+      *reinterpret_cast<const ffi::ftr_span*>(span),
+      *reinterpret_cast<ffi::ftr_loc_spans*>(&local_span));
 }
 
-ftr_loc_span ftr_create_loc_span_enter(const char *name) {
-  union _ftr_loc_span _mls = {
-      .f = fastrace_glue::ftr_create_loc_span_enter(name),
-  };
-  return std::move(_mls.c);
+ftr_loc_span ftr_create_loc_span_enter(const char* name) {
+  return call_rust_function<ftr_loc_span>(
+      &fastrace_glue::ftr_create_loc_span_enter, rust::Str(name));
 }
 
-void ftr_loc_span_add_prop(const char *key, const char *val) {
-  fastrace_glue::ftr_loc_span_add_prop(key, val);
+void ftr_loc_span_add_prop(const char* key, const char* val) {
+  fastrace_glue::ftr_loc_span_add_prop(rust::Str(key), rust::Str(val));
 }
 
-void ftr_loc_span_add_props(const char **keys, const char **vals, size_t n) {
+void ftr_loc_span_add_props(const char** keys, const char** vals, size_t n) {
+  std::vector<const char*> rust_keys(keys, keys + n);
+  std::vector<const char*> rust_vals(vals, vals + n);
   fastrace_glue::ftr_loc_span_add_props(
-      rust::Slice<const char *const>(keys, n),
-      rust::Slice<const char *const>(vals, n));
+      rust::Slice<const char* const>(rust_keys.data(), n),
+      rust::Slice<const char* const>(rust_vals.data(), n));
 }
 
-void ftr_loc_span_with_prop(ftr_loc_span *span, const char *key,
-                            const char *val) {
+void ftr_loc_span_with_prop(ftr_loc_span* span, const char* key,
+                            const char* val) {
   fastrace_glue::ftr_loc_span_with_prop(
-      *reinterpret_cast<ffi::ftr_loc_span *>(span), key, val);
+      *reinterpret_cast<ffi::ftr_loc_span*>(span), rust::Str(key),
+      rust::Str(val));
 }
 
-void ftr_loc_span_with_props(ftr_loc_span *span, const char **keys,
-                             const char **vals, size_t n) {
+void ftr_loc_span_with_props(ftr_loc_span* span, const char** keys,
+                             const char** vals, size_t n) {
+  std::vector<const char*> rust_keys(keys, keys + n);
+  std::vector<const char*> rust_vals(vals, vals + n);
   fastrace_glue::ftr_loc_span_with_props(
-      *reinterpret_cast<ffi::ftr_loc_span *>(span),
-      rust::Slice<const char *const>(keys, n),
-      rust::Slice<const char *const>(vals, n));
+      *reinterpret_cast<ffi::ftr_loc_span*>(span),
+      rust::Slice<const char* const>(rust_keys.data(), n),
+      rust::Slice<const char* const>(rust_vals.data(), n));
 }
 
-void ftr_add_ent_to_loc_par(const char *name, const char **keys,
-                            const char **vals, size_t n) {
+void ftr_add_ent_to_loc_par(const char* name, const char** keys,
+                            const char** vals, size_t n) {
+  std::vector<const char*> rust_keys(keys, keys + n);
+  std::vector<const char*> rust_vals(vals, vals + n);
   fastrace_glue::ftr_add_ent_to_loc_par(
-      name, rust::Slice<const char *const>(keys, n),
-      rust::Slice<const char *const>(vals, n));
+      rust::Str(name), rust::Slice<const char* const>(rust_keys.data(), n),
+      rust::Slice<const char* const>(rust_vals.data(), n));
 }
 
 void ftr_destroy_loc_span(ftr_loc_span span) {
-  fastrace_glue::ftr_destroy_loc_span(*(ffi::ftr_loc_span *)(&span));
+  fastrace_glue::ftr_destroy_loc_span(
+      *reinterpret_cast<ffi::ftr_loc_span*>(&span));
 }
 
-ftr_loc_coll ftr_start_loc_coll(void) {
-  union _ftr_loc_coll _mlc = {
-      .f = fastrace_glue::ftr_start_loc_coll(),
-  };
-  return std::move(_mlc.c);
+ftr_loc_coll ftr_start_loc_coll() {
+  return call_rust_function<ftr_loc_coll>(&fastrace_glue::ftr_start_loc_coll);
 }
 
 ftr_loc_spans ftr_collect_loc_spans(ftr_loc_coll lc) {
-  union _ftr_loc_spans _mls = {
-      .f = fastrace_glue::ftr_collect_loc_spans(*(ffi::ftr_loc_coll *)(&lc)),
-  };
-  return std::move(_mls.c);
+  return call_rust_function<ftr_loc_spans>(
+      &fastrace_glue::ftr_collect_loc_spans,
+      *reinterpret_cast<ffi::ftr_loc_coll*>(&lc));
 }
 
-ftr_coll_cfg ftr_create_def_coll_cfg(void) {
-  union _ftr_coll_cfg _mcc = {
-      .f = fastrace_glue::ftr_create_def_coll_cfg(),
-  };
-  return std::move(_mcc.c);
+ftr_coll_cfg ftr_create_def_coll_cfg() {
+  return call_rust_function<ftr_coll_cfg>(
+      &fastrace_glue::ftr_create_def_coll_cfg);
+}
+
+ftr_coll_cfg ftr_set_max_spans_per_trace(ftr_coll_cfg cfg, size_t max) {
+  return call_rust_function<ftr_coll_cfg>(
+      &fastrace_glue::ftr_set_max_spans_per_trace,
+      *reinterpret_cast<ffi::ftr_coll_cfg*>(&cfg), max);
 }
 
 ftr_coll_cfg ftr_set_report_interval(ftr_coll_cfg cfg, uint64_t ri) {
-  union _ftr_coll_cfg _mcc = {
-      .f = fastrace_glue::ftr_set_report_interval(*(ffi::ftr_coll_cfg *)(&cfg),
-                                                  ri),
-  };
-  return std::move(_mcc.c);
+  return call_rust_function<ftr_coll_cfg>(
+      &fastrace_glue::ftr_set_report_interval,
+      *reinterpret_cast<ffi::ftr_coll_cfg*>(&cfg), ri);
 }
 
-void ftr_set_cons_rptr(void) { fastrace_glue::ftr_set_cons_rptr(); }
+void ftr_set_cons_rptr() { fastrace_glue::ftr_set_cons_rptr(); }
 
-ftr_otlp_exp_cfg ftr_create_def_otlp_exp_cfg(void) {
-  union _ftr_otlp_exp_cfg _moec = {
-      .f = fastrace_glue::ftr_create_def_otlp_exp_cfg(),
-  };
-  return std::move(_moec.c);
+ftr_otlp_exp_cfg ftr_create_def_otlp_exp_cfg() {
+  return call_rust_function<ftr_otlp_exp_cfg>(
+      &fastrace_glue::ftr_create_def_otlp_exp_cfg);
 }
 
 ftr_otel_rptr ftr_create_otel_rptr(ftr_otlp_exp_cfg cfg) {
-  union _ftr_otel_rptr _mor = {
-      .f =
-          fastrace_glue::ftr_create_otel_rptr(*(ffi::ftr_otlp_exp_cfg *)(&cfg)),
-  };
-  return std::move(_mor.c);
+  return call_rust_function<ftr_otel_rptr>(
+      &fastrace_glue::ftr_create_otel_rptr,
+      *reinterpret_cast<ffi::ftr_otlp_exp_cfg*>(&cfg));
 }
 
 void ftr_destroy_otel_rptr(ftr_otel_rptr rptr) {
-  fastrace_glue::ftr_destroy_otel_rptr(*(ffi::ftr_otel_rptr *)(&rptr));
+  fastrace_glue::ftr_destroy_otel_rptr(
+      *reinterpret_cast<ffi::ftr_otel_rptr*>(&rptr));
 }
 
 void ftr_set_otel_rptr(ftr_otel_rptr rptr, ftr_coll_cfg cfg) {
-  fastrace_glue::ftr_set_otel_rptr(*(ffi::ftr_otel_rptr *)(&rptr),
-                                   *(ffi::ftr_coll_cfg *)(&cfg));
+  fastrace_glue::ftr_set_otel_rptr(
+      *reinterpret_cast<ffi::ftr_otel_rptr*>(&rptr),
+      *reinterpret_cast<ffi::ftr_coll_cfg*>(&cfg));
 }
 
-void ftr_flush(void) { fastrace_glue::ftr_flush(); }
+void ftr_flush() { fastrace_glue::ftr_flush(); }
+
+}  // extern "C"
+
+namespace fastrace {
+
+SpanContext::SpanContext() : ctx_(ftr_create_rand_span_ctx()) {}
+
+SpanContext::SpanContext(const ftr_span_ctx& ctx) : ctx_(ctx) {}
+
+ftr_span_ctx SpanContext::raw() const { return ctx_; }
+
+void SpanContext::setSampled(bool sampled) {
+  ctx_ = ftr_span_ctx_set_sampled(ctx_, sampled);
 }
+
+Span::Span(const char* name, const SpanContext& parent)
+    : span_(new ftr_span(ftr_create_root_span(name, parent.raw()))) {}
+
+Span::Span(const char* name, const Span& parent)
+    : span_(new ftr_span(ftr_create_child_span_enter(name, parent.raw()))) {}
+
+Span::Span(const char* name)
+    : span_(new ftr_span(ftr_create_child_span_enter_loc(name))) {}
+
+Span::~Span() {
+  if (span_) {
+    ftr_destroy_span(*span_);
+  }
+}
+
+void Span::cancel() {
+  if (span_) {
+    ftr_cancel_span(*span_);
+  }
+}
+
+void Span::addProperty(const std::string& key, const std::string& value) {
+  if (span_) {
+    ftr_span_with_prop(span_.get(), key.c_str(), value.c_str());
+  }
+}
+
+void Span::addProperties(
+    const std::vector<std::pair<std::string, std::string> >& properties) {
+  if (span_ && !properties.empty()) {
+    std::vector<const char*> keys;
+    std::vector<const char*> values;
+    for (size_t i = 0; i < properties.size(); ++i) {
+      keys.push_back(properties[i].first.c_str());
+      values.push_back(properties[i].second.c_str());
+    }
+    ftr_span_with_props(span_.get(), &keys[0], &values[0], properties.size());
+  }
+}
+
+void Span::addEvent(
+    const std::string& name,
+    const std::vector<std::pair<std::string, std::string> >& properties) {
+  if (span_ && !properties.empty()) {
+    std::vector<const char*> keys;
+    std::vector<const char*> values;
+    for (size_t i = 0; i < properties.size(); ++i) {
+      keys.push_back(properties[i].first.c_str());
+      values.push_back(properties[i].second.c_str());
+    }
+    ftr_add_ent_to_par(name.c_str(), span_.get(), &keys[0], &values[0],
+                       properties.size());
+  }
+}
+
+ftr_span* Span::raw() { return span_.get(); }
+
+const ftr_span* Span::raw() const { return span_.get(); }
+
+LocalParentGuard::LocalParentGuard(const Span& span)
+    : guard_(ftr_set_loc_par_to_span(span.raw())) {}
+
+LocalParentGuard::~LocalParentGuard() { ftr_destroy_loc_par_guar(guard_); }
+
+LocalSpan::LocalSpan(const char* name)
+    : span_(ftr_create_loc_span_enter(name)) {}
+
+LocalSpan::LocalSpan(LocalSpan&& other) noexcept : span_(other.span_) {
+  other.span_ = ftr_loc_span{};
+}
+
+LocalSpan& LocalSpan::operator=(LocalSpan&& other) noexcept {
+  if (this != &other) {
+    ftr_destroy_loc_span(span_);
+    span_ = other.span_;
+    other.span_ = ftr_loc_span{};
+  }
+  return *this;
+}
+LocalSpan::~LocalSpan() { ftr_destroy_loc_span(span_); }
+
+void LocalSpan::addProperty(const std::string& key, const std::string& value) {
+  ftr_loc_span_with_prop(&span_, key.c_str(), value.c_str());
+}
+
+void LocalSpan::addProperties(
+    const std::vector<std::pair<std::string, std::string> >& properties) {
+  if (!properties.empty()) {
+    std::vector<const char*> keys;
+    std::vector<const char*> values;
+    for (size_t i = 0; i < properties.size(); ++i) {
+      keys.push_back(properties[i].first.c_str());
+      values.push_back(properties[i].second.c_str());
+    }
+    ftr_loc_span_with_props(&span_, &keys[0], &values[0], properties.size());
+  }
+}
+
+void LocalSpan::addEvent(
+    const std::string& name,
+    const std::vector<std::pair<std::string, std::string> >& properties) {
+  if (!properties.empty()) {
+    std::vector<const char*> keys;
+    std::vector<const char*> values;
+    for (size_t i = 0; i < properties.size(); ++i) {
+      keys.push_back(properties[i].first.c_str());
+      values.push_back(properties[i].second.c_str());
+    }
+    ftr_add_ent_to_loc_par(name.c_str(), &keys[0], &values[0],
+                           properties.size());
+  }
+}
+
+CollectorConfig::CollectorConfig() : cfg_(ftr_create_def_coll_cfg()) {}
+
+void CollectorConfig::setMaxSpansPerTrace(size_t max) {
+  cfg_ = ftr_set_max_spans_per_trace(cfg_, max);
+}
+
+void CollectorConfig::setReportInterval(uint64_t interval) {
+  cfg_ = ftr_set_report_interval(cfg_, interval);
+}
+
+ftr_coll_cfg CollectorConfig::raw() const { return cfg_; }
+
+OTLPExporterConfig::OTLPExporterConfig()
+    : cfg_(ftr_create_def_otlp_exp_cfg()) {}
+
+ftr_otlp_exp_cfg OTLPExporterConfig::raw() const { return cfg_; }
+
+OpenTelemetryReporter::OpenTelemetryReporter(const OTLPExporterConfig& config)
+    : reporter_(ftr_create_otel_rptr(config.raw())) {}
+
+OpenTelemetryReporter::~OpenTelemetryReporter() {
+  ftr_destroy_otel_rptr(reporter_);
+}
+
+void OpenTelemetryReporter::setReporter(const CollectorConfig& config) {
+  ftr_set_otel_rptr(reporter_, config.raw());
+}
+
+OTLPExporterConfig createDefaultOTLPExporterConfig() {
+  return OTLPExporterConfig();
+}
+
+CollectorConfig createDefaultCollectorConfig() { return CollectorConfig(); }
+
+OpenTelemetryReporter createOpenTelemetryReporter(
+    const OTLPExporterConfig& config) {
+  return OpenTelemetryReporter(config);
+}
+
+void setOpenTelemetryReporter(OpenTelemetryReporter& reporter,
+                              const CollectorConfig& config) {
+  reporter.setReporter(config);
+}
+
+void setConsoleReporter() { ftr_set_cons_rptr(); }
+
+void flush() { ftr_flush(); }
+}  // namespace fastrace


### PR DESCRIPTION
- Replace C-style function calls with type-safe C++ wrappers
- Implement move semantics for Span and LocalSpan classes
- Use call_rust_function template for safer Rust-C++ interop
- Replace unions with reinterpret_cast for cleaner type conversions
- Add vector-based property handling for more flexible API
- Update examples to use new C++ interface
- Improve memory management with RAII principles
- Enhance code readability and maintainability

Close #3 