### PR TITLE
feat: optimize C++ interface and reduce memory allocations

### DIFF
--- a/examples/get_started2.cc
+++ b/examples/get_started2.cc
@@ -6,9 +6,9 @@
 #include <vector>
 
 int main() {
-  std::array<std::string, 10> keys = {"pk1", "pk2", "pk3", "pk4", "ck1",
+  std::array<const char*, 10> keys = {"pk1", "pk2", "pk3", "pk4", "ck1",
                                       "ck2", "ck3", "ck4", "ck5", "ck6"};
-  std::array<std::string, 10> vals = {"pv1", "pv2", "pv3", "pv4", "cv1",
+  std::array<const char*, 10> vals = {"pv1", "pv2", "pv3", "pv4", "cv1",
                                       "cv2", "cv3", "cv4", "cv5", "cv6"};
 
   fastrace::setConsoleReporter();
@@ -17,31 +17,31 @@ int main() {
     fastrace::SpanContext context;
     fastrace::Span rootSpan("root", context);
 
-    std::vector<std::pair<std::string, std::string>> parentEventProps = {
+    std::vector<std::pair<const char*, const char*>> parentEventProps = {
         {keys[0], vals[0]}, {keys[1], vals[1]}};
     rootSpan.addEvent("parent event", parentEventProps);
 
     rootSpan.addProperty("phello", "pworld");
-    std::vector<std::pair<std::string, std::string>> rootProps = {
+    std::vector<std::pair<const char*, const char*>> rootProps = {
         {keys[2], vals[2]}, {keys[3], vals[3]}};
     rootSpan.addProperties(rootProps);
 
     fastrace::LocalParentGuard guard(rootSpan);
     fastrace::LocalSpan childSpan("child");
 
-    std::vector<std::pair<std::string, std::string>> childEventProps = {
+    std::vector<std::pair<const char*, const char*>> childEventProps = {
         {keys[4], vals[4]}, {keys[5], vals[5]}};
     childSpan.addEvent("child event", childEventProps);
 
     childSpan.addProperty("chello", "cworld");
-    std::vector<std::pair<std::string, std::string>> childProps1 = {
+    std::vector<std::pair<const char*, const char*>> childProps1 = {
         {keys[6], vals[6]}, {keys[7], vals[7]}};
     childSpan.addProperties(childProps1);
 
-    childSpan.addProperty("chello2", "cworld2");
-    std::vector<std::pair<std::string, std::string>> childProps2 = {
+    childSpan.withProperty("chello2", "cworld2");
+    std::vector<std::pair<const char*, const char*>> childProps2 = {
         {keys[8], vals[8]}, {keys[9], vals[9]}};
-    childSpan.addProperties(childProps2);
+    childSpan.withProperties(childProps2);
   }
 
   fastrace::flush();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ mod ffi {
         /// Sets the `sampled` flag of the `SpanContext`.
         fn ftr_span_ctx_set_sampled(ctx: ftr_span_ctx, sampled: bool) -> ftr_span_ctx;
 
+        /// Create a place-holder span that never starts recording.
+        fn ftr_create_noop_span() -> ftr_span;
+
         /// Create a new trace and return its root span.
         ///
         /// Once destroyed (dropped), the root span automatically submits all associated child spans to the reporter.
@@ -266,6 +269,10 @@ pub fn ftr_create_span_ctx_loc() -> ftr_span_ctx {
 
 pub fn ftr_span_ctx_set_sampled(ctx: ftr_span_ctx, sampled: bool) -> ftr_span_ctx {
     unsafe { transmute(transmute::<ftr_span_ctx, SpanContext>(ctx).sampled(sampled)) }
+}
+
+pub fn ftr_create_noop_span() -> ftr_span {
+    unsafe { transmute(Span::noop()) }
 }
 
 pub fn ftr_create_root_span(name: &'static str, parent: ftr_span_ctx) -> ftr_span {


### PR DESCRIPTION
- Replace std::string with const char* in public APIs
- Remove std::unique_ptr wrapper for ftr_span
- Implement ftr_create_noop_span for placeholder spans
- Eliminate unnecessary vector allocations in C wrapper functions
- Add withProperty and withProperties methods to LocalSpan
- Update example code to use new const char* based APIs
- Remove unused includes (memory, string) from libfastrace.h
- Simplify Span and LocalSpan implementations using direct Rust FFI calls

Close #5 