### PR TITLE
feat: add uninstall target and update documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,3 +53,14 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libfastraceConfig.cmake"
                 "${CMAKE_CURRENT_BINARY_DIR}/libfastraceConfigVersion.cmake"
         DESTINATION lib/cmake/libfastrace
         )
+
+# Add uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ fastrace for C/C++.
 It's built on top of
 [fastrace in Rust](https://github.com/fast/fastrace) via [cxx](https://github.com/dtolnay/cxx).
 
+## Requirements
+
+- C++11 or later
+- Rust environment
 
 ## Prepare 
 
@@ -20,6 +24,14 @@ curl https://sh.rustup.rs -sSf | sh
 cmake -S . -B build && cmake --build build
 ## install to /usr/local
 sudo cmake --install build
+```
+
+## Uninstall
+
+To uninstall the library, use the following command:
+
+```bash
+sudo cmake --build build --target uninstall
 ```
 
 ## Run example

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+cmake_policy(SET CMP0048 NEW)
 project(Example)
-cmake_minimum_required(VERSION 3.5)
 set (CMAKE_C_STANDARD 11)
 set (CMAKE_CXX_STANDARD 11)
 


### PR DESCRIPTION
- Add uninstall target to CMakeLists.txt
- Update README with C++11 requirement and uninstall instructions
- Set minimum CMake version to 3.10 in examples
- Add CMP0048 policy in examples CMakeLists.txt

This change improves user experience by providing an easy way to uninstall the library and clarifies the project requirements.

Close #7 