### PR TITLE
build: modernize CMake configuration and fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,66 +1,120 @@
+# Minimum CMake version and project definition
 cmake_minimum_required(VERSION 3.10)
 cmake_policy(SET CMP0048 NEW)
 project(libfastrace VERSION 0.7.2)
-set (CMAKE_CXX_STANDARD 11)
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+# Build options
+option(BUILD_TESTING "Build the testing tree." OFF)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Set default build type if not specified
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build" FORCE)
+endif()
+
+# Configure Cargo build command based on build type
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CARGO_CMD cargo build --verbose --target-dir=${CMAKE_CURRENT_BINARY_DIR})
     set(TARGET_DIR "debug")
-else ()
+else()
     set(CARGO_CMD cargo build --release --target-dir=${CMAKE_CURRENT_BINARY_DIR})
     set(TARGET_DIR "release")
-endif ()
+endif()
 
+# Define paths for Rust-generated files
 set(RUST_PART_LIB "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libfastrace_rust.a")
 set(RUST_PART_CXX "${CMAKE_CURRENT_BINARY_DIR}/cxxbridge/libfastrace/src/lib.rs.cc")
 set(RUST_PART_H "${CMAKE_CURRENT_BINARY_DIR}/cxxbridge/libfastrace/src/lib.rs.h")
+
+# Custom command to build Rust part
 add_custom_command(
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml ${CMAKE_CURRENT_SOURCE_DIR}/src/lib.rs ${CMAKE_CURRENT_SOURCE_DIR}/build.rs
     OUTPUT ${RUST_PART_LIB} ${RUST_PART_CXX} ${RUST_PART_H}
-    COMMAND CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} RUSTFLAGS="${RUST_FLAGS}" ${CARGO_CMD}
+    DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/lib.rs
+        ${CMAKE_CURRENT_SOURCE_DIR}/build.rs
+    COMMAND CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}
+            RUSTFLAGS="${RUST_FLAGS}"
+            ${CARGO_CMD}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Building Rust library..."
 )
 
-include_directories(
-    ${CMAKE_CURRENT_BINARY_DIR}/cxxbridge/libfastrace/src
-    ${CMAKE_SOURCE_DIR}/include
+# Add library target
+add_library(libfastrace STATIC
+    src/libfastrace.cpp
+    ${RUST_PART_CXX}
 )
-add_library(libfastrace STATIC src/libfastrace.cpp ${RUST_PART_CXX})
-set_target_properties(libfastrace PROPERTIES PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/libfastrace.h;${RUST_PART_H}")
 
+# Configure include directories
+target_include_directories(libfastrace
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/cxxbridge/libfastrace/src>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+# Set library properties
+set_target_properties(libfastrace
+    PROPERTIES
+        OUTPUT_NAME "fastrace"
+        PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/libfastrace.h;${RUST_PART_H}"
+)
+
+# Generate version file
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     libfastraceConfigVersion.cmake
-    VERSION ${PACKAGE_VERSION}
+    VERSION ${PROJECT_VERSION}
     COMPATIBILITY AnyNewerVersion
 )
 
+# Install targets
 install(TARGETS libfastrace
-        EXPORT libfastraceTargets
-        LIBRARY DESTINATION lib
-        PUBLIC_HEADER DESTINATION include/libfastrace
-        )
+    EXPORT libfastraceTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    PUBLIC_HEADER DESTINATION include/libfastrace
+)
 
-install(FILES ${RUST_PART_LIB} DESTINATION lib)
+# Install Rust library
+install(FILES ${RUST_PART_LIB}
+    DESTINATION lib
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+)
 
+# Install CMake config files
 install(EXPORT libfastraceTargets
-        FILE libfastraceTargets.cmake
-        DESTINATION lib/cmake/libfastrace
-        )
+    FILE libfastraceTargets.cmake
+    NAMESPACE libfastrace::
+    DESTINATION lib/cmake/libfastrace
+)
 
 configure_file(libfastraceConfig.cmake.in libfastraceConfig.cmake @ONLY)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libfastraceConfig.cmake"
-                "${CMAKE_CURRENT_BINARY_DIR}/libfastraceConfigVersion.cmake"
-        DESTINATION lib/cmake/libfastrace
-        )
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/libfastraceConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/libfastraceConfigVersion.cmake"
+    DESTINATION lib/cmake/libfastrace
+)
 
 # Add uninstall target
 if(NOT TARGET uninstall)
-  configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-    IMMEDIATE @ONLY)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY
+    )
+    add_custom_target(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+    )
+endif()
 
-  add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+# Add tests if enabled
+if(BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
 endif()

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,58 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    execute_process(
+      COMMAND "@CMAKE_COMMAND@" -E remove "$ENV{DESTDIR}${file}"
+      OUTPUT_VARIABLE rm_out
+      RESULT_VARIABLE rm_retval
+    )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else()
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()
+
+set(PACKAGE_DIRS
+  "@CMAKE_INSTALL_PREFIX@/lib/cmake/libfastrace"
+  "@CMAKE_INSTALL_PREFIX@/lib/cmake"
+  "@CMAKE_INSTALL_PREFIX@/lib"
+)
+
+function(check_and_remove_if_empty dir)
+  if(EXISTS "${dir}")
+    file(GLOB dir_contents "${dir}/*")
+    list(LENGTH dir_contents count)
+    if(count EQUAL 0)
+      if("${dir}" STREQUAL "@CMAKE_INSTALL_PREFIX@/lib")
+        if(NOT EXISTS "${dir}/.." OR NOT IS_DIRECTORY "${dir}/..")
+          message(STATUS "Skipping system lib directory: ${dir}")
+          return()
+        endif()
+      endif()
+
+      execute_process(
+        COMMAND "@CMAKE_COMMAND@" -E remove_directory "${dir}"
+        OUTPUT_VARIABLE rm_out
+        RESULT_VARIABLE rm_retval
+      )
+      if("${rm_retval}" STREQUAL 0)
+        message(STATUS "Removed empty directory: ${dir}")
+      endif()
+    else()
+      message(STATUS "Directory not empty, skipping: ${dir}")
+    endif()
+  endif()
+endfunction()
+
+message(STATUS "Removing empty package directories...")
+foreach(dir ${PACKAGE_DIRS})
+  check_and_remove_if_empty("${dir}")
+endforeach()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,35 +1,68 @@
 cmake_minimum_required(VERSION 3.10)
 cmake_policy(SET CMP0048 NEW)
-project(Example)
-set (CMAKE_C_STANDARD 11)
-set (CMAKE_CXX_STANDARD 11)
+project(Example VERSION 1.0.0)
 
-# using local repository
-find_package(libfastrace 0.7.2)
+# Set C/C++ standards
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Find required package
+find_package(libfastrace 0.7.2 REQUIRED)
+if(NOT libfastrace_FOUND)
+    message(FATAL_ERROR "libfastrace not found!")
+endif()
+
+# Helper function to add examples
 function(add_example target_name source_file)
-  add_executable(${target_name} ${source_file})
-  target_link_libraries(${target_name} libfastrace fastrace_rust)
+    add_executable(${target_name} ${source_file})
+    target_link_libraries(${target_name}
+        PRIVATE
+            libfastrace::libfastrace  # Use namespace
+            fastrace_rust
+    )
+    # Add compile options if needed
+    target_compile_options(${target_name}
+        PRIVATE
+            $<$<C_COMPILER_ID:GNU>:-Wall -Wextra>
+            $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra>
+    )
 endfunction()
 
+# Define source files
 set(C_EXAMPLE_SOURCES
-  get_started.c
-  synchronous.c
-  asynchronous.c
+    get_started.c
+    synchronous.c
+    asynchronous.c
 )
 
 set(CXX_EXAMPLE_SOURCES
-  get_started2.cc
-  synchronous2.cc
-  asynchronous2.cc
+    get_started2.cc
+    synchronous2.cc
+    asynchronous2.cc
 )
 
+# Build C examples
 foreach(source_file ${C_EXAMPLE_SOURCES})
-  get_filename_component(target_name ${source_file} NAME_WE)
-  add_example(${target_name} ${source_file})
+    get_filename_component(target_name ${source_file} NAME_WE)
+    add_example(${target_name} ${source_file})
 endforeach()
 
+# Build C++ examples
 foreach(source_file ${CXX_EXAMPLE_SOURCES})
-  get_filename_component(target_name ${source_file} NAME_WE)
-  add_example(${target_name} ${source_file})
+    get_filename_component(target_name ${source_file} NAME_WE)
+    add_example(${target_name} ${source_file})
 endforeach()
+
+# Optional: Add install targets for examples
+option(INSTALL_EXAMPLES "Install example executables" OFF)
+if(INSTALL_EXAMPLES)
+    foreach(source_file ${C_EXAMPLE_SOURCES} ${CXX_EXAMPLE_SOURCES})
+        get_filename_component(target_name ${source_file} NAME_WE)
+        install(TARGETS ${target_name}
+            RUNTIME DESTINATION bin/examples
+        )
+    endforeach()
+endif()

--- a/examples/asynchronous.c
+++ b/examples/asynchronous.c
@@ -137,6 +137,7 @@ void __attribute__((noinline)) foo(void) {
 }
 
 void *produce(void *arg) {
+  (void)arg;
   ftr_span_ctx p = ftr_create_rand_span_ctx();
   ftr_span r = ftr_create_root_span("root", p);
   ftr_loc_par_guar g = ftr_set_loc_par_to_span(&r);

--- a/src/libfastrace.cpp
+++ b/src/libfastrace.cpp
@@ -8,8 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include "lib.rs.h"
-
 namespace {
 
 template <typename CType, typename RustType, typename... Args>


### PR DESCRIPTION
- Replace global include_directories with target_include_directories
- Add proper version handling using PROJECT_VERSION
- Add namespace for exported targets (libfastrace::)
- Improve build type and compiler standard settings
- Add proper uninstall target with directory cleanup
- Fix unused parameter warning in examples
- Add optional example installation

The changes follow modern CMake best practices and improve build robustness.

close #11 