### PR TITLE
feat: add default constructor for Span class

### DIFF
--- a/include/libfastrace.h
+++ b/include/libfastrace.h
@@ -329,6 +329,9 @@ class Span {
   /** @brief Copy assignment operator (deleted to ensure unique ownership) */
   Span &operator=(const Span &) = delete;
 
+  /** @brief Creates a new noop Span. */
+  Span();
+
   /** @brief Destroys the span, submitting it to the reporter if it's a root
    * span. */
   ~Span();

--- a/src/libfastrace.cpp
+++ b/src/libfastrace.cpp
@@ -273,6 +273,10 @@ Span& Span::operator=(Span&& other) noexcept {
   return *this;
 }
 
+Span::Span() {
+  span_ = call_rust_function<ftr_span>(&fastrace_glue::ftr_create_noop_span);
+}
+
 Span::~Span() { ftr_destroy_span(span_); }
 
 void Span::cancel() { ftr_cancel_span(span_); }


### PR DESCRIPTION
Add a default constructor that creates noop spans, making the API more intuitive and consistent with Rust's behavior.

close #13 