### PR TITLE
chore: update fastrace and configure tokio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,15 @@ name = "fastrace_rust"
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
-cxx = "1.0.128"
+cxx = "1.0.130"
 libc = "0.2"
-fastrace = { version = "=0.7.2", features = ["enable"] }
-fastrace-opentelemetry = "=0.7.2"
-opentelemetry = { version = "=0.24", features = ["trace"] }
-opentelemetry-otlp = { version = "=0.17", features = ["trace"] }
-opentelemetry_sdk = { version = "=0.24", features = ["trace"] }
-tokio = { version = "1.38", features = ["rt", "rt-multi-thread"] }
+fastrace = { version = "=0.7.4", features = ["enable"] }
+fastrace-opentelemetry = "=0.7.4"
+opentelemetry = { version = "=0.26", features = ["trace"] }
+opentelemetry-otlp = { version = "=0.26", features = ["trace"] }
+opentelemetry_sdk = { version = "=0.26", features = ["trace"] }
+tokio = { version = "1.41", features = ["full"] }
 once_cell = "1.19.0"
 
 [build-dependencies]
-cxx-build = "1.0.106"
+cxx-build = "1.0.130"


### PR DESCRIPTION
- Update fastrace to 0.7.4 and related dependencies
- Configure tokio with 2 worker threads and full features
- Update OpenTelemetry stack to latest compatible versions

Performance improvement by optimizing runtime configuration.

close #15 